### PR TITLE
Convert Spark datatime string, remove trailing '.nnnZ'

### DIFF
--- a/src/sparkapi/base.py
+++ b/src/sparkapi/base.py
@@ -41,6 +41,8 @@ class BaseObject(metaclass=ABCMeta):
             return None
         if fmt is None:
             fmt = self._format
+
+        value = re.sub('\.\d+Z', '', value)
         naive_ts = arrow.get(value, fmt).naive
         return arrow.get(naive_ts).to('utc').datetime
 


### PR DESCRIPTION
When I try to use this, I get an error:

arrow.parser.ParserMatchError: Failed to match 'YYYY-MM-DDTHH:mm:ss' when parsing '2019-03-28T17:33:09.837Z'

Apparently the datetime string from WebexTeams object includes the trailing '.nnnZ', which is some kind timezone offset. 